### PR TITLE
[EPO-973] Support multipe skyviewer widgets.

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -28,7 +28,7 @@
     "jquery": "^1.8",
     "jupyter-js-widgets": "^2.1.4",
     "lodash": "^4.17.10",
-    "paper-select-tool": "^0.1.8",
+    "paper-select-tool": "^0.2.9",
     "underscore": "^1.8.3"
   },
   "jupyterlab": {

--- a/js/src/jupyter-aladin.js
+++ b/js/src/jupyter-aladin.js
@@ -111,15 +111,16 @@ var ViewAladin = widgets.DOMWidgetView.extend({
 	sCanvas.id = 'selection-canvas' + parseInt(Math.random()*1000000);
 	this.el.appendChild(sCanvas);
 	this.pst = pst;
-	window.PST = pst;
-	pst.lasso(sCanvas);
+	this.pst_settings = new pst.Settings();
+	this.pst_settings.alpha = 0.04;
+	this.pst.lasso(this.pst_settings, sCanvas);
 	that._canvasResize(sCanvas, rCanvas);
 
-	var selection_el = this.pst.settings.scope.view._element;
-	this.pst.settings.scope.view.on('mouseup', function(event) {
+	var selection_el = this.pst_settings.scope.view._element;
+	this.pst_settings.scope.view.on('mouseup', function(event) {
 	    that._selection_changed();
 	});
-	this.pst.settings.scope.view.on('mousedown', function(event) {
+	this.pst_settings.scope.view.on('mousedown', function(event) {
 	    that._hide_catalogs();
 	});
 
@@ -145,7 +146,7 @@ var ViewAladin = widgets.DOMWidgetView.extend({
 	canvas.style.position = "absolute";
 	canvas.style.top = "0px";
 	canvas.style.left = "0px";
-	pst.settings.scope.view.setViewSize(canvas.width, canvas.height);
+	this.pst_settings.scope.view.setViewSize(canvas.width, canvas.height);
     },
     
     _hide_catalogs: function() {
@@ -167,7 +168,7 @@ var ViewAladin = widgets.DOMWidgetView.extend({
 	   && this.al.selection_cat) {
 	    var sources = lodash.cloneDeep(that.al.selection_cat.sources),
 		sources_xy = [],
-		scope = that.pst.settings.scope,
+		scope = that.pst_settings.scope,
 		cat = that.al.selection_cat,
 		cat0 = that.al.view.catalogs[0],
 		cat_found = false;
@@ -182,7 +183,7 @@ var ViewAladin = widgets.DOMWidgetView.extend({
 		var xy = that.al.world2pix(s.ra, s.dec);
 		sources_xy.push({"point": new scope.Point(xy[0], xy[1]), "id": s.data.objID});
 	    });
-	    var selection = that.pst.pointsFilter(sources_xy),
+	    var selection = that.pst.pointsFilter(that.pst_settings, sources_xy),
 		selection_ids = [];
 	    selection.forEach(function(s) {
 		selection_ids.push(s['id']);
@@ -346,7 +347,7 @@ var ViewAladin = widgets.DOMWidgetView.extend({
 	       && that.al.view.catalogs
 	       && that.al.view.catalogs.length > 0
 	       && that.al.view.catalogs[0].sources) {
-		var scope = that.pst.settings.scope,
+		var scope = that.pst_settings.scope,
 		    cat = lodash.cloneDeep(that.al.selection_cat),
 		    cat0 = that.al.view.catalogs[0],
 		    cat_found = false,


### PR DESCRIPTION
  * Use version 0.2.9 of the paper-select-tool library.
  * Use an instance of settings. `this.pst_settings` instead of `pst.settings`.

	modified:   js/package.json
	modified:   js/src/jupyter-aladin.js